### PR TITLE
feat: debounce localStorage saves

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useMemo, useState } from 'react'
+import useDebouncedLocalStorage from './hooks/useDebouncedLocalStorage'
 import { motion, AnimatePresence, animate, useMotionValue, useTransform } from 'framer-motion'
 
 const fmtRUB = (n) => new Intl.NumberFormat('ru-RU',{style:'currency',currency:'RUB',maximumFractionDigits:0}).format(isFinite(n)?Math.round(n):0)
@@ -22,11 +23,11 @@ export default function App(){
   const [commissionPct,setCommissionPct]=useState(()=> localStorage.getItem(K.comm) || '10')
   const [markupPct,setMarkupPct]=useState(()=> localStorage.getItem(K.mark) || '50')
 
-  useEffect(()=>localStorage.setItem(K.base,baseCny),[baseCny])
-  useEffect(()=>localStorage.setItem(K.rate,rate),[rate])
-  useEffect(()=>localStorage.setItem(K.logi,logistics),[logistics])
-  useEffect(()=>localStorage.setItem(K.comm,commissionPct),[commissionPct])
-  useEffect(()=>localStorage.setItem(K.mark,markupPct),[markupPct])
+  useDebouncedLocalStorage(K.base, baseCny, 300)
+  useDebouncedLocalStorage(K.rate, rate, 300)
+  useDebouncedLocalStorage(K.logi, logistics, 300)
+  useDebouncedLocalStorage(K.comm, commissionPct, 300)
+  useDebouncedLocalStorage(K.mark, markupPct, 300)
 
   const calc = useMemo(()=>{
     const baseRub = clamp(Number(baseCny))*clamp(Number(rate))

--- a/src/hooks/useDebouncedLocalStorage.js
+++ b/src/hooks/useDebouncedLocalStorage.js
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+
+export default function useDebouncedLocalStorage(key, value, delay = 300) {
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      localStorage.setItem(key, value)
+    }, delay)
+    return () => clearTimeout(timeout)
+  }, [key, value, delay])
+}


### PR DESCRIPTION
## Summary
- add `useDebouncedLocalStorage` hook to delay storing values
- use debounced storage for base cost, rate, logistics, commission and markup values

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a1b4af8c7483329c8b5c0be24d4b0e